### PR TITLE
v0.3.0

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,3 +1,5 @@
+# This file is machine-generated - editing it directly is not advised
+
 [[Arpack]]
 deps = ["BinaryProvider", "Libdl", "LinearAlgebra", "Random", "SparseArrays", "Test"]
 git-tree-sha1 = "1ce1ce9984683f0b6a587d5bdbc688ecb480096f"
@@ -27,9 +29,9 @@ version = "0.4.1"
 
 [[CategoricalArrays]]
 deps = ["Compat", "Future", "Missings", "Printf", "Reexport", "Requires"]
-git-tree-sha1 = "11419d157ab75a54a8af63315e7a279a593971bc"
+git-tree-sha1 = "94d16e77dfacc59f6d6c1361866906dbb65b6f6b"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.5.1"
+version = "0.5.2"
 
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "Test", "TranscodingStreams"]
@@ -57,15 +59,15 @@ version = "0.2.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "ec61a16eed883ad0cfa002d7489b3ce6d039bb9a"
+git-tree-sha1 = "49269e311ffe11ac5b334681d212329002a9832a"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "1.4.0"
+version = "1.5.1"
 
 [[Conda]]
 deps = ["Compat", "JSON", "VersionParsing"]
-git-tree-sha1 = "fb86fe40cb5b35990e368709bfdc1b46dbb99dac"
+git-tree-sha1 = "b625d802587c2150c279a40a646fba63f9bd8187"
 uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.1.1"
+version = "1.2.0"
 
 [[Crayons]]
 deps = ["Test"]
@@ -75,9 +77,9 @@ version = "1.0.0"
 
 [[DataFrames]]
 deps = ["CategoricalArrays", "CodecZlib", "Compat", "DataStreams", "Dates", "InteractiveUtils", "IteratorInterfaceExtensions", "LinearAlgebra", "Missings", "Printf", "Random", "Reexport", "SortingAlgorithms", "Statistics", "StatsBase", "TableTraits", "Tables", "Test", "TranscodingStreams", "Unicode", "WeakRefStrings"]
-git-tree-sha1 = "ad34fefb72b18a8dd5c17fab9089d11111b61935"
+git-tree-sha1 = "9cfed75401d25d281076eb5d82de148ac2933f9e"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.14.1"
+version = "0.17.1"
 
 [[DataStreams]]
 deps = ["Dates", "Missings", "Test", "WeakRefStrings"]
@@ -87,9 +89,9 @@ version = "0.4.1"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
-git-tree-sha1 = "8fc6e166e24fda04b2b648d4260cdad241788c54"
+git-tree-sha1 = "ca971f03e146cf144a9e2f2ce59674f5bf0e8038"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.14.0"
+version = "0.15.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -101,24 +103,24 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[DiffEqDiffTools]]
 deps = ["LinearAlgebra", "Test"]
-git-tree-sha1 = "67700c9fc82033ec68a145bc650f6b9debdf9103"
+git-tree-sha1 = "4b21dd83c341412a0607334ac64bb5593a4bd583"
 uuid = "01453d9d-ee7c-5054-8395-0335cb756afa"
-version = "0.7.1"
+version = "0.8.0"
 
 [[DiffResults]]
 deps = ["Compat", "StaticArrays"]
-git-tree-sha1 = "db8acf46717b13d6c48deb7a12007c7f85a70cf7"
+git-tree-sha1 = "34a4a1e8be7bc99bc9c611b895b5baf37a80584c"
 uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
-version = "0.0.3"
+version = "0.0.4"
 
 [[DiffRules]]
 deps = ["Random", "Test"]
-git-tree-sha1 = "c49ec69428ffea0c1d1bbdc63d1a70f5df5860ad"
+git-tree-sha1 = "26b96a1a506b06cb272ef60568d478adab039b96"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "0.0.7"
+version = "0.0.9"
 
 [[Distributed]]
-deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[Distributions]]
@@ -135,16 +137,16 @@ version = "0.5.3"
 
 [[ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "InteractiveUtils", "LinearAlgebra", "NaNMath", "Random", "SparseArrays", "SpecialFunctions", "StaticArrays", "Test"]
-git-tree-sha1 = "b91250044374764e7c29af59a774c4b8d6100b6e"
+git-tree-sha1 = "e393bd3b9102659fb24fe88caedec41f2bc2e7de"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.1"
+version = "0.10.2"
 
 [[Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[InteractiveUtils]]
-deps = ["LinearAlgebra", "Markdown"]
+deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[IteratorInterfaceExtensions]]
@@ -158,12 +160,6 @@ deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
 git-tree-sha1 = "1f7a25b53ec67f5e9422f1f551ee216503f4a0fa"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.20.0"
-
-[[Juno]]
-deps = ["Base64", "Logging", "Media", "Profile", "Test"]
-git-tree-sha1 = "3c29a199713e7ec62cfdc11f44d7760219d5f658"
-uuid = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
-version = "0.5.3"
 
 [[LaTeXStrings]]
 deps = ["Compat"]
@@ -185,10 +181,10 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[LsqFit]]
-deps = ["Calculus", "Distributions", "LinearAlgebra", "OptimBase", "Random", "Test"]
-git-tree-sha1 = "5c1b5ab85e120c6d1734e7f5670aac22fe69270c"
+deps = ["Distributions", "LinearAlgebra", "NLSolversBase", "OptimBase", "Random", "StatsBase", "Test"]
+git-tree-sha1 = "831607572cefd71ee5ca4a49aefc29ce3c20502b"
 uuid = "2fda8390-95c7-5789-9bda-21331edee243"
-version = "0.6.0"
+version = "0.7.3"
 
 [[MacroTools]]
 deps = ["Compat"]
@@ -200,26 +196,20 @@ version = "0.4.4"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[Media]]
-deps = ["MacroTools", "Test"]
-git-tree-sha1 = "75a54abd10709c01f1b86b84ec225d26e840ed58"
-uuid = "e89f7d12-3494-54d1-8411-f7d8b9ae1f27"
-version = "0.5.0"
-
 [[Missings]]
 deps = ["Dates", "InteractiveUtils", "SparseArrays", "Test"]
-git-tree-sha1 = "adc26d2ee85a49c413464110d922cf21efc9d233"
+git-tree-sha1 = "d1d2585677f2bd93a97cfeb8faa7a0de0f982042"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.3.1"
+version = "0.4.0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[NLSolversBase]]
 deps = ["Calculus", "DiffEqDiffTools", "DiffResults", "Distributed", "ForwardDiff", "LinearAlgebra", "Random", "SparseArrays", "Test"]
-git-tree-sha1 = "ebfb2e96970151753575b9c4d31d47e5ae8382a5"
+git-tree-sha1 = "2bd568eda045f5ad2cbd311d71e09d7165ab2bf6"
 uuid = "d41bc354-129a-5804-8e4c-c37616107c6c"
-version = "7.1.1"
+version = "7.3.0"
 
 [[NaNMath]]
 deps = ["Compat"]
@@ -228,10 +218,10 @@ uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 version = "0.3.2"
 
 [[OhMyREPL]]
-deps = ["Crayons", "Logging", "Markdown", "Pkg", "Printf", "REPL", "Test", "Tokenize"]
-git-tree-sha1 = "33e70d910da8a2af6cc8f0b7fb25f56192c8d714"
+deps = ["Crayons", "Markdown", "Pkg", "Printf", "REPL", "Test", "Tokenize"]
+git-tree-sha1 = "5c183fc5d9bd657541775d719106cf8b025e9295"
 uuid = "5fb14364-9ced-5910-84b2-373655c76a03"
-version = "0.4.0"
+version = "0.5.0"
 
 [[OptimBase]]
 deps = ["Compat", "NLSolversBase", "Printf", "Reexport", "Test"]
@@ -247,15 +237,15 @@ version = "1.0.2"
 
 [[PDMats]]
 deps = ["Arpack", "LinearAlgebra", "SparseArrays", "SuiteSparse", "Test"]
-git-tree-sha1 = "9e3e7a5c9b8cfdba8c01a1bcae38fe0144936fda"
+git-tree-sha1 = "b6c91fc0ab970c0563cbbe69af18d741a49ce551"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.9.5"
+version = "0.9.6"
 
 [[Parameters]]
 deps = ["Markdown", "OrderedCollections", "REPL", "Test"]
-git-tree-sha1 = "eec0fe16344cc14aa2e6251874ab30d62aff4f7c"
+git-tree-sha1 = "70bdbfb2bceabb15345c0b54be4544813b3444e4"
 uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-version = "0.10.2"
+version = "0.10.3"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -265,15 +255,11 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[[Profile]]
-deps = ["Printf"]
-uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
-
 [[ProgressMeter]]
 deps = ["Distributed", "Printf", "Random", "Test"]
-git-tree-sha1 = "37e7d3982c8d4610196829c01387dd561756aedc"
+git-tree-sha1 = "48058bc11607676e5bbc0b974af79106c6200787"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
-version = "0.8.0"
+version = "0.9.0"
 
 [[PyCall]]
 deps = ["Compat", "Conda", "MacroTools", "Statistics", "VersionParsing"]
@@ -283,15 +269,15 @@ version = "1.18.5"
 
 [[PyPlot]]
 deps = ["Colors", "Compat", "LaTeXStrings", "PyCall", "VersionParsing"]
-git-tree-sha1 = "777c48006c57c8bd322d2032267085983a5fd50f"
+git-tree-sha1 = "dd9f4a0bba3933f907640a567e1ce2a8ab44c58c"
 uuid = "d330b81b-6aea-500a-939a-2ce795aea3ee"
-version = "2.6.3"
+version = "2.7.0"
 
 [[QuadGK]]
 deps = ["DataStructures", "LinearAlgebra", "Test"]
-git-tree-sha1 = "7e8dff9c205f36eceaf6e62a43ff851637ca45fc"
+git-tree-sha1 = "3ce467a8e76c6030d4c3786e7d3a73442017cdc0"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-version = "2.0.2"
+version = "2.0.3"
 
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]
@@ -350,25 +336,25 @@ version = "0.7.2"
 
 [[StaticArrays]]
 deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
-git-tree-sha1 = "97c4bf0f647488dd7ac01ea12be5885f88762938"
+git-tree-sha1 = "1eb114d6e23a817cd3e99abc3226190876d7c898"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.10.0"
+version = "0.10.2"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[StatsBase]]
-deps = ["DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "Test"]
-git-tree-sha1 = "2722397d88f8ffef551948f6c20e1d74a743298c"
+deps = ["DataStructures", "DelimitedFiles", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "Test"]
+git-tree-sha1 = "7b596062316c7d846b67bf625d5963a832528598"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.26.0"
+version = "0.27.0"
 
 [[StatsFuns]]
 deps = ["Rmath", "SpecialFunctions", "Test"]
-git-tree-sha1 = "d14bb7b03defd2deaa5675646f6783089e0556f0"
+git-tree-sha1 = "b3a4e86aa13c732b8a8c0ba0c3d3264f55e6bb3e"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "0.7.0"
+version = "0.8.0"
 
 [[SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "SparseArrays"]
@@ -376,15 +362,15 @@ uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions", "Test"]
-git-tree-sha1 = "da062a2c31f16178f68190243c24140801720a43"
+git-tree-sha1 = "eba4b1d0a82bdd773307d652c6e5f8c82104c676"
 uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
-version = "0.4.0"
+version = "0.4.1"
 
 [[Tables]]
-deps = ["Requires", "Test"]
-git-tree-sha1 = "c7fb447deab835fa70ce6717e78c68b0f466a42c"
+deps = ["IteratorInterfaceExtensions", "LinearAlgebra", "Requires", "TableTraits", "Test"]
+git-tree-sha1 = "37be2ed169d5771c1ac8d516d3bcb0093c49966e"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "0.1.11"
+version = "0.1.15"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
@@ -392,9 +378,9 @@ uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[Tokenize]]
 deps = ["Printf", "Test"]
-git-tree-sha1 = "4a9fefb5c5c831c6fc06fcc5d2ae7399918bb587"
+git-tree-sha1 = "3e83f60b74911d3042d3550884ca2776386a02b8"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.2"
+version = "0.5.3"
 
 [[TranscodingStreams]]
 deps = ["Pkg", "Random", "Test"]
@@ -409,7 +395,7 @@ uuid = "30578b45-9adc-5946-b283-645ec420af67"
 version = "0.4.0"
 
 [[UUIDs]]
-deps = ["Random"]
+deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
@@ -423,22 +409,22 @@ version = "1.1.3"
 
 [[WeakRefStrings]]
 deps = ["Missings", "Random", "Test"]
-git-tree-sha1 = "1087e8be380f2c8b96434b02bb1150fc1c511135"
+git-tree-sha1 = "cf70c71939e621a3fac4156a8bfb3c80d745794a"
 uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
-version = "0.5.3"
+version = "0.5.7"
 
 [[filehandling]]
-deps = ["DataFrames", "Dates", "Juno"]
-git-tree-sha1 = "fddd7a6cc7abd05c548f9c57d52297a81308b90e"
+deps = ["DataFrames", "Dates"]
+git-tree-sha1 = "bdc21da1f995fcdd4fd112ff8fb5ad19c79aa97c"
 repo-rev = "master"
 repo-url = "https://github.com/pb866/filehandling.git"
 uuid = "4b8ed5e0-8069-11e8-094b-3f5425e6acdd"
-version = "0.4.1"
+version = "1.0.0"
 
 [[pyp]]
 deps = ["DataFrames", "Dates", "LaTeXStrings", "LinearAlgebra", "OhMyREPL", "Parameters", "PyPlot", "filehandling"]
-git-tree-sha1 = "4126a60f8c78c3a776261e59bd1ef329febd84e5"
-repo-rev = "master"
-repo-url = "https://github.com/pb866/pyp.git"
+git-tree-sha1 = "5fb96e828d553195798b89bf3b50b21556a4b0eb"
+repo-rev = "dev"
+repo-url = "/Applications/bin/jl.aux/pyp/"
 uuid = "1f59166c-d923-11e8-01b9-e713fdda0351"
-version = "0.2.0"
+version = "0.3.0-DEV"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -27,9 +27,9 @@ version = "0.4.1"
 
 [[CategoricalArrays]]
 deps = ["Compat", "Future", "Missings", "Printf", "Reexport", "Requires"]
-git-tree-sha1 = "64651a0315fc342e7e35d03d67b2da920937c9be"
+git-tree-sha1 = "11419d157ab75a54a8af63315e7a279a593971bc"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.5.0"
+version = "0.5.1"
 
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "Test", "TranscodingStreams"]
@@ -360,9 +360,9 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[StatsBase]]
 deps = ["DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "Test"]
-git-tree-sha1 = "723193a13e8078cec6dcd0b8fe245c8bfd81690e"
+git-tree-sha1 = "2722397d88f8ffef551948f6c20e1d74a743298c"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.25.0"
+version = "0.26.0"
 
 [[StatsFuns]]
 deps = ["Rmath", "SpecialFunctions", "Test"]
@@ -428,17 +428,17 @@ uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 version = "0.5.3"
 
 [[filehandling]]
-deps = ["DataFrames", "Juno"]
-git-tree-sha1 = "a0ba5ec76455ec48184f97fa39d994d4b3b4ec4a"
+deps = ["DataFrames", "Dates", "Juno"]
+git-tree-sha1 = "fddd7a6cc7abd05c548f9c57d52297a81308b90e"
 repo-rev = "master"
 repo-url = "https://github.com/pb866/filehandling.git"
 uuid = "4b8ed5e0-8069-11e8-094b-3f5425e6acdd"
-version = "0.3.1"
+version = "0.4.1"
 
 [[pyp]]
 deps = ["DataFrames", "Dates", "LaTeXStrings", "LinearAlgebra", "OhMyREPL", "Parameters", "PyPlot", "filehandling"]
-git-tree-sha1 = "9f20cb48da31edc145e2b3413b541295039a98a8"
+git-tree-sha1 = "4126a60f8c78c3a776261e59bd1ef329febd84e5"
 repo-rev = "master"
 repo-url = "https://github.com/pb866/pyp.git"
 uuid = "1f59166c-d923-11e8-01b9-e713fdda0351"
-version = "0.1.1"
+version = "0.2.0"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "MCMphotolysis"
 uuid = "37f95c2c-7f9b-11e8-13ad-816be0d1e117"
 authors = ["Peter Bräuer <pb866@york.ac.uk>"]
 julia = "≥0.7"
-version = "0.2.0"
+version = "0.3.0-DEV"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/Project.toml
+++ b/Project.toml
@@ -2,12 +2,11 @@ name = "MCMphotolysis"
 uuid = "37f95c2c-7f9b-11e8-13ad-816be0d1e117"
 authors = ["Peter Bräuer <pb866@york.ac.uk>"]
 julia = "≥0.7"
-version = "0.3.0-DEV"
+version = "0.3.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"

--- a/README.md
+++ b/README.md
@@ -147,11 +147,7 @@ If you get an error message, follow the the instructions of the error message, e
 Pkg.build("CodecZlib")
 ```
 
-<<<<<<< HEAD
-If PyPlot crashes or fails to install, try running Julia with the system python rather than 
-=======
-If PyPlot crashes, try running Julia with the system python rather than
->>>>>>> rel/0.2.1
+If PyPlot crashes or fails to install, try running Julia with the system python rather than
 the miniconda python version by rebuilding python with:
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The package is tested against MacOS 10.14.1.
 Installation
 ------------
 
-Install the Package by adding it to your environment going to the package 
+Install the Package by adding it to your environment going to the package
 manager typing `]` in the julia prompt and in the package manager the following commands:
 
 ```julia
@@ -41,15 +41,15 @@ The package has two functions:
   l<sub>c0</sub>,l<sub>c1</sub>,m,n MCM photolysis parameterisations with a
   dependence on the overlying ozone column.
 
-Both functions rely on TUV 5.2 (or version with same format) output files, 
-with j for every reaction at the chosen height level. For the updated 
+Both functions rely on TUV 5.2 (or version with same format) output files,
+with j for every reaction at the chosen height level. For the updated
 parameterisations, you need TUV files for every ozone column in the chosen
 range (derived for 50 to 600DU every 50DU in the MCM). Files need to be
 saved in the format `<scen>.<O3col>.txt`, where `<scen>` is a scenario name
 that can be chosen freely and `<O3col` is the ozone column in DU. As TUV
 allows only 6 characters for file names, `<scen>` must not be longer than
 2 characters.
-  
+
 ### The original MCM photolysis parameterisation
 
 Function `j_oldpars` derives parameters for every reaction with non-zero
@@ -99,7 +99,7 @@ R² are determined and returned as `StatData`.
 
 ### Updated MCM photolysis parameterisation with ozone column dependence
 
-Function `j_parameters` returns a refined parameterisation, which includes a dependence on the overlying ozone column. In the original parameterisation, 
+Function `j_parameters` returns a refined parameterisation, which includes a dependence on the overlying ozone column. In the original parameterisation,
 `l` has been redefined to include a second order exponential dependence on the
 ozone column. At 350DU, both parameterisations are identical.
 
@@ -113,7 +113,7 @@ jvals, params = j_parameters("M4")
 ```
 
 The function works as above and by default creates a folder `params_<scen>`,
-where the ozone column dependence of `l` is plotted in `lpar.pdf` and 
+where the ozone column dependence of `l` is plotted in `lpar.pdf` and
 _j_ value fits and TUV data are compared in `jvalues.pdf`. A formatted files
 `parameters.dat` lists all parameters and standard errors. Additionally,
 `parameters.csv` lists the data in a csv file.
@@ -147,7 +147,11 @@ If you get an error message, follow the the instructions of the error message, e
 Pkg.build("CodecZlib")
 ```
 
+<<<<<<< HEAD
 If PyPlot crashes or fails to install, try running Julia with the system python rather than 
+=======
+If PyPlot crashes, try running Julia with the system python rather than
+>>>>>>> rel/0.2.1
 the miniconda python version by rebuilding python with:
 
 ```julia
@@ -162,6 +166,12 @@ and copying the output.
 
 Version history
 ===============
+
+Version 0.2.1
+-------------
+- Improved error handling: assign `Inf` to sigmal, if conversion fails to avoid
+  errors from LsqFit and the abortion of the script
+- Fix #4
 
 Version 0.2.0
 -------------

--- a/src/MCMphotolysis.jl
+++ b/src/MCMphotolysis.jl
@@ -63,7 +63,8 @@ end
 # export public functions
 export j_oldpars,
        j_parameters,
-       PhotData
+       PhotData,
+       StatData
 
 
 function __init__()

--- a/src/fitTUV.jl
+++ b/src/fitTUV.jl
@@ -104,8 +104,12 @@ function fitl(ldata, order, o3col, params350, rxn)
     l  = deepcopy(fit.param)
     l[[1,2,4]] *= 10.0^order[i]
     push!(lpar, l)
-    errl = standard_error(fit)
-    sigmal = abs.((l./errl.*10.0^order[i] .+ params350.sigma[i][1]/params350.l[i]).*l)
+    if fit.converged
+      errl = standard_error(fit)
+      sigmal = abs.((l./errl.*10.0^order[i] .+ params350.sigma[i][1]/params350.l[i]).*l)
+    else
+      sigmal = [Inf, Inf, Inf, Inf, Inf]
+    end
     push!(sigmas, vcat(sigmal, params350.sigma[i][2:3]))
     push!(converged, !fail)
   end
@@ -133,10 +137,10 @@ function convergel(o3col::Vector{Float64}, lpar::Vector{Float64},
     if test == "p0"
       fit = curve_fit(lnew, o3col, lpar, fit.param)
     elseif test == "low"
-      fit = curve_fit(lnew, o3col[1+counter:end], lpar[1+counter:end,i], fit.param)
+      fit = curve_fit(lnew, o3col[1+counter:end], lpar[1+counter:end], fit.param)
     elseif test == "high"
       fit = curve_fit(lnew, o3col[counter:end-counter],
-        lpar[counter:end-counter,i], fit.param)
+        lpar[counter:end-counter], fit.param)
     end
     if fit.converged
       println(error_msg[1],counter,error_msg[2])

--- a/src/rdfiles.jl
+++ b/src/rdfiles.jl
@@ -11,24 +11,27 @@ function setup_files(scen, output)
   # Test script argument and ask for input file, if missing
   if isempty(scen)
     println("Enter name for TUV scenario")
-    scen = input("(Name of output file without \'.txt\'): ")
+    print("(Name of output file without \'.txt\'): ")
+    scen = readline()
   end
 
   # Create output folder
   iofolder = "./params_"*strip(scen)
-  if output  try mkdir(iofolder)
+  if output ≠ false && output ≠ "None"  try mkdir(iofolder)
   catch
     print("\033[95mFolder '$iofolder' already exists! Overwrite ")
-    confirm = input("(\033[4mY\033[0m\033[95mes/\033[4mN\033[0m\033[95mo)?\033[0m ")
+    print("(\033[4mY\033[0m\033[95mes/\033[4mN\033[0m\033[95mo)?\033[0m ")
+    confirm = readline()
     if !isempty(confirm) && lowercase(confirm[1]) == 'y'
       cd(iofolder); files = readdir(); [rm(file) for file in files ]; cd("..")
-    else println("Programme aborted. Exit code '98'."); exit(98)
+    else println("Stop function 'setup_files'."); return nothing, nothing
     end
   end  end
 
   # Define TUV file
   ifile = scen*".txt"
-  ifile = test_file(ifile)
+  ifile = filetest(ifile)
+  if ifile == ""  return nothing, nothing  end
 
   # return file and folder names
   return ifile, iofolder
@@ -49,7 +52,8 @@ function getO3files(scen, output)
   # Test script argument and ask for input file, if missing
   while !any(occursin.(scen,readdir()))
     println("Enter a valid name for a TUV scenario")
-    scen = input("(Name of output file without \'.txt\'): ")
+    print("(Name of output file without \'.txt\'): ")
+    scen = readline()
   end
 
   # Create output folder
@@ -57,10 +61,11 @@ function getO3files(scen, output)
   if output ≠ false  try mkdir(iofolder)
   catch
     print("\033[95mFolder '$iofolder' already exists! Overwrite ")
-    confirm = input("(\033[4mY\033[0m\033[95mes/\033[4mN\033[0m\033[95mo)?\033[0m ")
+    print("(\033[4mY\033[0m\033[95mes/\033[4mN\033[0m\033[95mo)?\033[0m ")
+    confirm = readline()
     if !isempty(confirm) && lowercase(confirm[1:1]) == "y"
       cd(iofolder); files = readdir(); for file in files  rm(file)  end; cd("..")
-    else println("Programme aborted. Exit code '98'."); exit(98)
+    else println("Stop function 'getO3files'."); return nothing, nothing, nothing
     end
   end  end
 
@@ -79,16 +84,16 @@ end #function get_fnames
 
 
 """
-    getTUVdata(inpfile, O3col)
+    getTUVdata(inpfile, O3col, MCMversion)
 
 From vector `inpfile` with file names of all ozone scenarios and vector `O3col`
 with all ozone column values, get a vector of `TUVdata` with j value related data.
 """
-function getTUVdata(inpfile, O3col)
+function getTUVdata(inpfile, O3col, MCMversion)
   # Read j values
   jvals = []
   for i = 1:length(inpfile)
-    j = readTUV(inpfile[i], O3col[i])
+    j = readTUV(inpfile[i], DU = O3col[i], MCMversion = MCMversion)
     push!(jvals, j)
   end
 


### PR DESCRIPTION
Version 0.3.0
-------------
- Updated database files and new kwarg `MCMversion` for correct MCM reaction numbers
- Remove `StatData`; `RMSE` and `R2` are not supported in v0.3.0
- New options to only print output to text files in `j_oldpars`; additional
  semicolon-separated output
- Rename kwarg `O3col` to `DU`
- On failure, don't exit Julia, only abort function and return nothing
- Rename internal functions
- Code clean-up and bug fixes